### PR TITLE
#7: More Elm like enum generation

### DIFF
--- a/source/Generate/Decoder.elm
+++ b/source/Generate/Decoder.elm
@@ -104,7 +104,7 @@ defaultValue type_ default =
         String_ (Enum name enum) ->
             case decodeString string default of
                 Ok default ->
-                    (enumTagName name default)
+                    (enumTagName default)
 
                 Err err ->
                     Debug.crash "Invalid default value" err default
@@ -145,7 +145,7 @@ renderEnum (Definition _ isRequired type_) =
 
 renderEnumEach : String -> String -> ( String, String )
 renderEnumEach enumName value =
-    ( "\"" ++ value ++ "\"", "Result.Ok " ++ (sanitize <| enumTagName enumName value) )
+    ( "\"" ++ value ++ "\"", "Result.Ok " ++ (sanitize <| enumTagName value) )
 
 
 renderEnumFail : String -> ( String, String )

--- a/source/Generate/Type.elm
+++ b/source/Generate/Type.elm
@@ -103,12 +103,12 @@ renderEnum : Definition -> Maybe String
 renderEnum (Definition _ isRequired type_) =
     case type_ of
         String_ (Enum name enum) ->
-            Just <| unionType (sanitize name) (List.map (sanitize << enumTagName name) enum)
+            Just <| unionType (sanitize name) (List.map enumTagName enum)
 
         _ ->
             Nothing
 
 
-enumTagName : String -> String -> String
-enumTagName typeName tagName =
-    typeName ++ capitalize tagName
+enumTagName : String -> String
+enumTagName =
+    (sanitize << capitalize)

--- a/source/Swagger/Parse.elm
+++ b/source/Swagger/Parse.elm
@@ -145,4 +145,4 @@ makeEnum name enum =
 
 enumName : String -> String
 enumName name =
-    "Enum" ++ capitalize name
+    capitalize name

--- a/tests/Integration/Decoder.elm
+++ b/tests/Integration/Decoder.elm
@@ -3,7 +3,7 @@ module Integration.Decoder exposing (..)
 import Test exposing (..)
 import Expect exposing (Expectation, fail)
 import Json.Decode exposing (decodeString)
-import Decoder exposing (Article, decodeArticle, decodeErrorResponse, decodeGroup, decodeRules, EnumDisplaySize(EnumDisplaySizeLarge, EnumDisplaySizeSmall))
+import Decoder exposing (Article, decodeArticle, decodeErrorResponse, decodeGroup, decodeRules, DisplaySize(Large, Small))
 
 
 articleJson =
@@ -42,7 +42,7 @@ expectedArticle =
     , type_ = Just "article"
     , title = "Article one"
     , category_id = "blog"
-    , displaySize = EnumDisplaySizeLarge
+    , displaySize = Large
     , nested =
         Just
             { one = Just "1"
@@ -100,7 +100,7 @@ expectedGroup =
       , type_ = Nothing
       , title = "Article one"
       , category_id = "blog"
-      , displaySize = EnumDisplaySizeSmall
+      , displaySize = Small
       , nested = Nothing
       , rules = Nothing
       , sponsored = False


### PR DESCRIPTION
* Remove the `"Enum"` prefix of the enum name.
* Remove the enum name prefix from the enum values.
* Add sanitize to `enumTagName`, otherwise it was not used by the `Generate.Decoder` that also relied on the `enumTagName` functionality.