### PR TITLE
Fix lower case key with value type object bug

### DIFF
--- a/dist/elm.js
+++ b/dist/elm.js
@@ -1564,8 +1564,7 @@ function toString(v)
 	var type = typeof v;
 	if (type === 'function')
 	{
-		var name = v.func ? v.func.name : v.name;
-		return '<function' + (name === '' ? '' : ':') + name + '>';
+		return '<function>';
 	}
 
 	if (type === 'boolean')
@@ -2072,6 +2071,13 @@ var _elm_lang$core$List$sortWith = _elm_lang$core$Native_List.sortWith;
 var _elm_lang$core$List$sortBy = _elm_lang$core$Native_List.sortBy;
 var _elm_lang$core$List$sort = function (xs) {
 	return A2(_elm_lang$core$List$sortBy, _elm_lang$core$Basics$identity, xs);
+};
+var _elm_lang$core$List$singleton = function (value) {
+	return {
+		ctor: '::',
+		_0: value,
+		_1: {ctor: '[]'}
+	};
 };
 var _elm_lang$core$List$drop = F2(
 	function (n, list) {
@@ -2891,7 +2897,7 @@ function endsWith(sub, str)
 function indexes(sub, str)
 {
 	var subLen = sub.length;
-	
+
 	if (subLen < 1)
 	{
 		return _elm_lang$core$Native_List.Nil;
@@ -2904,74 +2910,78 @@ function indexes(sub, str)
 	{
 		is.push(i);
 		i = i + subLen;
-	}	
-	
+	}
+
 	return _elm_lang$core$Native_List.fromArray(is);
 }
+
 
 function toInt(s)
 {
 	var len = s.length;
+
+	// if empty
 	if (len === 0)
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+		return intErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
+
+	// if hex
+	var c = s[0];
+	if (c === '0' && s[1] === 'x')
 	{
-		if (len === 1)
+		for (var i = 2; i < len; ++i)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			var c = s[i];
+			if (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'))
+			{
+				continue;
+			}
+			return intErr(s);
 		}
-		start = 1;
+		return _elm_lang$core$Result$Ok(parseInt(s, 16));
 	}
-	for (var i = start; i < len; ++i)
+
+	// is decimal
+	if (c > '9' || (c < '0' && c !== '-' && c !== '+'))
+	{
+		return intErr(s);
+	}
+	for (var i = 1; i < len; ++i)
 	{
 		var c = s[i];
 		if (c < '0' || '9' < c)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			return intErr(s);
 		}
 	}
+
 	return _elm_lang$core$Result$Ok(parseInt(s, 10));
 }
 
+function intErr(s)
+{
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int");
+}
+
+
 function toFloat(s)
 {
-	var len = s.length;
-	if (len === 0)
+	// check if it is a hex, octal, or binary number
+	if (s.length === 0 || /[\sxbo]/.test(s))
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+		return floatErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
-	{
-		if (len === 1)
-		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-		}
-		start = 1;
-	}
-	var dotCount = 0;
-	for (var i = start; i < len; ++i)
-	{
-		var c = s[i];
-		if ('0' <= c && c <= '9')
-		{
-			continue;
-		}
-		if (c === '.')
-		{
-			dotCount += 1;
-			if (dotCount <= 1)
-			{
-				continue;
-			}
-		}
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-	}
-	return _elm_lang$core$Result$Ok(parseFloat(s));
+	var n = +s;
+	// faster isNaN check
+	return n === n ? _elm_lang$core$Result$Ok(n) : floatErr(s);
 }
+
+function floatErr(s)
+{
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float");
+}
+
 
 function toList(str)
 {
@@ -4407,11 +4417,6 @@ function badToString(problem)
 				problem = problem.rest;
 				break;
 
-			case 'index':
-				context += '[' + problem.index + ']';
-				problem = problem.rest;
-				break;
-
 			case 'oneOf':
 				var problems = problem.problems;
 				for (var i = 0; i < problems.length; i++)
@@ -5393,15 +5398,8 @@ function setupIncomingPort(name, callback)
 		sentBeforeInit.push(value);
 	}
 
-	function postInitSend(incomingValue)
+	function postInitSend(value)
 	{
-		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
-		if (result.ctor === 'Err')
-		{
-			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
-		}
-
-		var value = result._0;
 		var temp = subs;
 		while (temp.ctor !== '[]')
 		{
@@ -5412,7 +5410,13 @@ function setupIncomingPort(name, callback)
 
 	function send(incomingValue)
 	{
-		currentSend(incomingValue);
+		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
+		if (result.ctor === 'Err')
+		{
+			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
+		}
+
+		currentSend(result._0);
 	}
 
 	return { send: send };
@@ -6232,9 +6236,9 @@ function on(name, options, decoder)
 
 function equalEvents(a, b)
 {
-	if (!a.options === b.options)
+	if (a.options !== b.options)
 	{
-		if (a.stopPropagation !== b.stopPropagation || a.preventDefault !== b.preventDefault)
+		if (a.options.stopPropagation !== b.options.stopPropagation || a.options.preventDefault !== b.options.preventDefault)
 		{
 			return false;
 		}
@@ -7510,7 +7514,7 @@ function normalRenderer(parentNode, view)
 var rAF =
 	typeof requestAnimationFrame !== 'undefined'
 		? requestAnimationFrame
-		: function(callback) { callback(); };
+		: function(callback) { setTimeout(callback, 1000 / 60); };
 
 function makeStepper(domNode, view, initialVirtualNode, eventNode)
 {
@@ -9094,7 +9098,10 @@ var _user$project$Generate_Decoder$renderObjectDecoder = F2(
 	function (safeName, properties) {
 		return A2(
 			_user$project$Codegen_Function$pipeline,
-			A2(_elm_lang$core$Basics_ops['++'], 'decode ', safeName),
+			A2(
+				_elm_lang$core$Basics_ops['++'],
+				'decode ',
+				_user$project$Codegen_Utils$capitalize(safeName)),
 			A2(_elm_lang$core$List$map, _user$project$Generate_Decoder$renderObjectDecoderProperty, properties));
 	});
 var _user$project$Generate_Decoder$renderObjectDecoderProperty = function (_p9) {

--- a/source/Generate/Decoder.elm
+++ b/source/Generate/Decoder.elm
@@ -75,7 +75,7 @@ renderObjectDecoder : String -> Properties -> String
 renderObjectDecoder safeName properties =
     properties
         |> List.map renderObjectDecoderProperty
-        |> pipeline ("decode " ++ safeName)
+        |> pipeline ("decode " ++ (capitalize safeName))
 
 
 renderObjectDecoderProperty : Definition -> String

--- a/tests/Integration/Decoder.elm
+++ b/tests/Integration/Decoder.elm
@@ -32,6 +32,7 @@ articleJson =
     "UpperCasedFieldSubfield": "test"
   },
   "lowerCaseDefinitionRef": true,
+  "lowerCaseDefinitionObjectRef": {},
   "$ref": "ref"
 }
 """
@@ -61,6 +62,7 @@ expectedArticle =
         { upperCasedFieldSubfield = "test"
         }
     , lowerCaseDefinitionRef = Just True
+    , lowerCaseDefinitionObjectRef = Just {}
     , ref = Just "ref"
     }
 
@@ -108,6 +110,7 @@ expectedGroup =
             { upperCasedFieldSubfield = "test"
             }
       , lowerCaseDefinitionRef = Nothing
+      , lowerCaseDefinitionObjectRef = Nothing
       , ref = Nothing
       }
     ]

--- a/tests/fixtures/swagger.json
+++ b/tests/fixtures/swagger.json
@@ -101,6 +101,9 @@
         },
         "lowerCaseDefinitionRef": {
           "$ref": "#/definitions/lowerCaseDefinition"
+        },
+        "lowerCaseDefinitionObjectRef": {
+          "$ref": "#/definitions/lowerCaseDefinitionObject"
         }
       }
     },
@@ -132,6 +135,9 @@
     "lowerCaseDefinition": {
       "type": "boolean",
       "description": "I know, but it's still allowed..."
+    },
+    "lowerCaseDefinitionObject": {
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
Having a lower case key with a value type object will fail, because
the type definition will be defined in upper case but the decoder
function argument will be lower case.

swagger.json example
```
    "lowerCaseDefinitionObject": {
      "type": "object"
    }
```
will result in 
```
decodeLowerCaseDefinitionObject : Decoder LowerCaseDefinitionObject
decodeLowerCaseDefinitionObject =
    decode lowerCaseDefinitionObject
```
The compiler will grouch about it as it doesn't know the type `lowerCaseDefinitionObject` but only the type `LowerCaseDefinitionObject`.

@ahultgren Let me know what you think. Happy for any feedback!

I will look into implementing the map feature from issue #10 tomorrow.

Related to issue #10 and [Alertmanager PR](https://github.com/prometheus/alertmanager/pull/698)