### PR TITLE
Support dictionary data structure

### DIFF
--- a/dist/elm.js
+++ b/dist/elm.js
@@ -8327,6 +8327,9 @@ var _user$project$Codegen_Type$wrap = F2(
 var _user$project$Codegen_Type$maybe = function (body) {
 	return A2(_user$project$Codegen_Type$wrap, 'Maybe', body);
 };
+var _user$project$Codegen_Type$dict = function (typeName) {
+	return A2(_elm_lang$core$Basics_ops['++'], 'Dict String ', typeName);
+};
 var _user$project$Codegen_Type$list = function (body) {
 	return A2(_user$project$Codegen_Type$wrap, 'List', body);
 };
@@ -8461,6 +8464,9 @@ var _user$project$Swagger_Type$Enum_ = F2(
 	});
 var _user$project$Swagger_Type$String_ = function (a) {
 	return {ctor: 'String_', _0: a};
+};
+var _user$project$Swagger_Type$Dict_ = function (a) {
+	return {ctor: 'Dict_', _0: a};
 };
 var _user$project$Swagger_Type$Array_ = function (a) {
 	return {ctor: 'Array_', _0: a};
@@ -8629,13 +8635,41 @@ var _user$project$Swagger_Decode$decodeProperties = function (_p8) {
 		_user$project$Swagger_Decode$property(_p9._0),
 		_p9._1);
 };
+var _user$project$Swagger_Decode$objectOrDict = function (_p10) {
+	var _p11 = _p10;
+	var _p12 = {ctor: '_Tuple2', _0: _p11._1, _1: _p11._2};
+	_v6_2:
+	do {
+		if (_p12.ctor === '_Tuple2') {
+			if (_p12._0.ctor === 'Nothing') {
+				if (_p12._1.ctor === 'Just') {
+					return _user$project$Swagger_Type$Dict_(_p12._1._0);
+				} else {
+					break _v6_2;
+				}
+			} else {
+				return _user$project$Swagger_Type$Object_(
+					_user$project$Swagger_Type$Properties(
+						A2(
+							_elm_lang$core$List$map,
+							_user$project$Swagger_Decode$property(_p11._0),
+							_p12._0._0)));
+			}
+		} else {
+			break _v6_2;
+		}
+	} while(false);
+	return _user$project$Swagger_Type$Object_(
+		_user$project$Swagger_Type$Properties(
+			{ctor: '[]'}));
+};
 var _user$project$Swagger_Decode$stringOrEnum = F2(
 	function ($default, $enum) {
-		var _p10 = $enum;
-		if (_p10.ctor === 'Nothing') {
+		var _p13 = $enum;
+		if (_p13.ctor === 'Nothing') {
 			return _user$project$Swagger_Type$String_($default);
 		} else {
-			return A2(_user$project$Swagger_Type$Enum_, $default, _p10._0);
+			return A2(_user$project$Swagger_Type$Enum_, $default, _p13._0);
 		}
 	});
 var _user$project$Swagger_Decode$decodeString = A2(
@@ -8667,11 +8701,11 @@ var _user$project$Swagger_Decode$decodePrimitive = function (constructor) {
 var _user$project$Swagger_Decode$extractRef = function (ref) {
 	var parsed = A2(
 		_elm_lang$core$Maybe$andThen,
-		function (_p11) {
+		function (_p14) {
 			return _elm_lang$core$List$head(
 				function (_) {
 					return _.submatches;
-				}(_p11));
+				}(_p14));
 		},
 		_elm_lang$core$List$head(
 			A3(
@@ -8679,9 +8713,9 @@ var _user$project$Swagger_Decode$extractRef = function (ref) {
 				_elm_lang$core$Regex$AtMost(1),
 				_elm_lang$core$Regex$regex('^#/definitions/(.+)$'),
 				ref)));
-	var _p12 = parsed;
-	if ((_p12.ctor === 'Just') && (_p12._0.ctor === 'Just')) {
-		return _p12._0._0;
+	var _p15 = parsed;
+	if ((_p15.ctor === 'Just') && (_p15._0.ctor === 'Just')) {
+		return _p15._0._0;
 	} else {
 		return A2(
 			_elm_lang$core$Basics_ops['++'],
@@ -8696,9 +8730,9 @@ var _user$project$Swagger_Decode$extractRef = function (ref) {
 };
 var _user$project$Swagger_Decode$decodeRef = A2(
 	_elm_lang$core$Json_Decode$map,
-	function (_p13) {
+	function (_p16) {
 		return _user$project$Swagger_Type$Ref_(
-			_user$project$Swagger_Decode$extractRef(_p13));
+			_user$project$Swagger_Decode$extractRef(_p16));
 	},
 	A3(
 		_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$required,
@@ -8706,7 +8740,7 @@ var _user$project$Swagger_Decode$decodeRef = A2(
 		_elm_lang$core$Json_Decode$string,
 		_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$decode(_elm_lang$core$Basics$identity)));
 var _user$project$Swagger_Decode$decodeType = _elm_lang$core$Json_Decode$lazy(
-	function (_p14) {
+	function (_p17) {
 		return A2(
 			_elm_lang$core$Json_Decode$andThen,
 			_user$project$Swagger_Decode$decodeTypeByType,
@@ -8725,14 +8759,14 @@ var _user$project$Swagger_Decode$decodeType = _elm_lang$core$Json_Decode$lazy(
 								return {ctor: '_Tuple2', _0: v0, _1: v1};
 							})))));
 	});
-var _user$project$Swagger_Decode$decodeTypeByType = function (_p15) {
-	var _p16 = _p15;
-	var _p17 = _p16._1;
-	if (_p17.ctor === 'Just') {
+var _user$project$Swagger_Decode$decodeTypeByType = function (_p18) {
+	var _p19 = _p18;
+	var _p20 = _p19._1;
+	if (_p20.ctor === 'Just') {
 		return _user$project$Swagger_Decode$decodeRef;
 	} else {
-		var _p18 = _p16._0;
-		switch (_p18) {
+		var _p21 = _p19._0;
+		switch (_p21) {
 			case 'string':
 				return _user$project$Swagger_Decode$decodeString;
 			case 'integer':
@@ -8744,63 +8778,68 @@ var _user$project$Swagger_Decode$decodeTypeByType = function (_p15) {
 			case 'array':
 				return _user$project$Swagger_Decode$decodeArray;
 			default:
-				return _elm_lang$core$Json_Decode$lazy(
-					function (_p19) {
-						return _user$project$Swagger_Decode$decodeObject;
-					});
+				return _user$project$Swagger_Decode$decodeObject;
 		}
 	}
 };
 var _user$project$Swagger_Decode$decodeArray = A2(
 	_elm_lang$core$Json_Decode$map,
-	function (_p20) {
+	function (_p22) {
 		return _user$project$Swagger_Type$Array_(
-			_user$project$Swagger_Type$Items(_p20));
+			_user$project$Swagger_Type$Items(_p22));
 	},
 	A3(
 		_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$required,
 		'items',
 		_elm_lang$core$Json_Decode$lazy(
-			function (_p21) {
+			function (_p23) {
 				return _user$project$Swagger_Decode$decodeType;
 			}),
 		_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$decode(_elm_lang$core$Basics$identity)));
 var _user$project$Swagger_Decode$decodeObject = A2(
 	_elm_lang$core$Json_Decode$map,
-	function (_p22) {
-		return _user$project$Swagger_Type$Object_(
-			_user$project$Swagger_Type$Properties(_p22));
-	},
-	A2(
-		_elm_lang$core$Json_Decode$map,
-		_user$project$Swagger_Decode$decodeProperties,
-		A4(
-			_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$optional,
+	_user$project$Swagger_Decode$objectOrDict,
+	A3(
+		_user$project$Swagger_Decode$maybe,
+		'additionalProperties',
+		_elm_lang$core$Json_Decode$lazy(
+			function (_p24) {
+				return _user$project$Swagger_Decode$decodeType;
+			}),
+		A3(
+			_user$project$Swagger_Decode$maybe,
 			'properties',
 			_elm_lang$core$Json_Decode$lazy(
-				function (_p23) {
+				function (_p25) {
 					return _elm_lang$core$Json_Decode$keyValuePairs(_user$project$Swagger_Decode$decodeType);
 				}),
-			{ctor: '[]'},
 			A4(
 				_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$optional,
 				'required',
 				_elm_lang$core$Json_Decode$list(_elm_lang$core$Json_Decode$string),
 				{ctor: '[]'},
 				_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$decode(
-					F2(
-						function (v0, v1) {
-							return {ctor: '_Tuple2', _0: v0, _1: v1};
+					F3(
+						function (v0, v1, v2) {
+							return {ctor: '_Tuple3', _0: v0, _1: v1, _2: v2};
 						}))))));
+var _user$project$Swagger_Decode$decodeDict = A3(
+	_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$required,
+	'additionalProperties',
+	_elm_lang$core$Json_Decode$lazy(
+		function (_p26) {
+			return _user$project$Swagger_Decode$decodeType;
+		}),
+	_NoRedInk$elm_decode_pipeline$Json_Decode_Pipeline$decode(_user$project$Swagger_Type$Dict_));
 var _user$project$Swagger_Decode$decodeTypes = A2(
 	_elm_lang$core$Json_Decode$map,
 	_user$project$Swagger_Definition$definitions,
 	A2(
 		_elm_lang$core$Json_Decode$map,
 		_elm_lang$core$List$map(
-			function (_p24) {
-				var _p25 = _p24;
-				return A3(_user$project$Swagger_Definition$definition, _elm_lang$core$Maybe$Nothing, _p25._0, _p25._1);
+			function (_p27) {
+				var _p28 = _p27;
+				return A3(_user$project$Swagger_Definition$definition, _elm_lang$core$Maybe$Nothing, _p28._0, _p28._1);
 			}),
 		_elm_lang$core$Json_Decode$keyValuePairs(_user$project$Swagger_Decode$decodeType)));
 var _user$project$Swagger_Decode$decodeSwagger = A3(
@@ -8829,25 +8868,38 @@ var _user$project$Swagger_Flatten$flattenProperty = F3(
 	});
 var _user$project$Swagger_Flatten$flattenType = F4(
 	function (parentNames, name, type_, definitions) {
-		var prependSelf = _user$project$Swagger_Definition$prepend(
-			A3(
-				_user$project$Swagger_Definition$definition,
-				_elm_lang$core$Maybe$Just(parentNames),
-				name,
-				type_));
-		var childParentNames = {ctor: '::', _0: name, _1: parentNames};
-		var _p2 = type_;
-		switch (_p2.ctor) {
-			case 'Object_':
-				return prependSelf(
-					A3(_user$project$Swagger_Flatten$flattenProperties, childParentNames, _p2._0, definitions));
-			case 'Array_':
-				return prependSelf(
-					A3(_user$project$Swagger_Flatten$flattenItems, childParentNames, _p2._0, definitions));
-			case 'Enum_':
-				return prependSelf(definitions);
-			default:
-				return definitions;
+		flattenType:
+		while (true) {
+			var prependSelf = _user$project$Swagger_Definition$prepend(
+				A3(
+					_user$project$Swagger_Definition$definition,
+					_elm_lang$core$Maybe$Just(parentNames),
+					name,
+					type_));
+			var childParentNames = {ctor: '::', _0: name, _1: parentNames};
+			var _p2 = type_;
+			switch (_p2.ctor) {
+				case 'Object_':
+					return prependSelf(
+						A3(_user$project$Swagger_Flatten$flattenProperties, childParentNames, _p2._0, definitions));
+				case 'Array_':
+					return prependSelf(
+						A3(_user$project$Swagger_Flatten$flattenItems, childParentNames, _p2._0, definitions));
+				case 'Dict_':
+					var _v2 = childParentNames,
+						_v3 = 'Property',
+						_v4 = _p2._0,
+						_v5 = definitions;
+					parentNames = _v2;
+					name = _v3;
+					type_ = _v4;
+					definitions = _v5;
+					continue flattenType;
+				case 'Enum_':
+					return prependSelf(definitions);
+				default:
+					return definitions;
+			}
 		}
 	});
 var _user$project$Swagger_Flatten$flattenItems = F3(
@@ -8879,6 +8931,17 @@ var _user$project$Swagger_Flatten$flattenEachRoot = F2(
 							_0: name,
 							_1: {ctor: '[]'}
 						},
+						_p5._0,
+						definitions);
+				case 'Dict_':
+					return A4(
+						_user$project$Swagger_Flatten$flattenType,
+						{
+							ctor: '::',
+							_0: name,
+							_1: {ctor: '[]'}
+						},
+						'Property',
 						_p5._0,
 						definitions);
 				default:
@@ -8932,6 +8995,8 @@ var _user$project$Generate_Type$renderPropertyType = F3(
 			case 'Object_':
 				return A2(_user$project$Generate_Utils$nestedTypeName, parentName, name);
 			case 'Array_':
+				return A2(_user$project$Generate_Utils$nestedTypeName, parentName, name);
+			case 'Dict_':
 				return A2(_user$project$Generate_Utils$nestedTypeName, parentName, name);
 			case 'Enum_':
 				return A2(_user$project$Generate_Utils$nestedTypeName, parentName, name);
@@ -9014,6 +9079,10 @@ var _user$project$Generate_Type$renderType = function (definition) {
 						name,
 						'Item',
 						_user$project$Swagger_Type$getItemsType(_p7._0))));
+		case 'Dict_':
+			return typeAliasDecl(
+				_user$project$Codegen_Type$dict(
+					A3(_user$project$Generate_Type$renderPropertyType, name, 'Property', _p7._0)));
 		default:
 			return typeAliasDecl(
 				_user$project$Generate_Utils$typeName(_p7._0));
@@ -9077,6 +9146,8 @@ var _user$project$Generate_Decoder$renderPropertyDecoder = F3(
 				return A2(_user$project$Generate_Utils$nestedDecoderName, parentName, name);
 			case 'Array_':
 				return A2(_user$project$Generate_Utils$nestedDecoderName, parentName, name);
+			case 'Dict_':
+				return A2(_user$project$Generate_Utils$nestedDecoderName, parentName, name);
 			case 'Enum_':
 				return A2(_user$project$Generate_Utils$nestedDecoderName, parentName, name);
 			case 'String_':
@@ -9103,8 +9174,8 @@ var _user$project$Generate_Decoder$defaultValue = F2(
 					_elm_lang$core$Native_Utils.crash(
 						'Generate.Decoder',
 						{
-							start: {line: 107, column: 21},
-							end: {line: 107, column: 32}
+							start: {line: 115, column: 21},
+							end: {line: 115, column: 32}
 						}),
 					'Invalid default value',
 					_p2._0,
@@ -9180,6 +9251,13 @@ var _user$project$Generate_Decoder$renderObjectBody = F2(
 				_user$project$Generate_Decoder$renderObjectDecoderProperty(name),
 				_p9._0));
 	});
+var _user$project$Generate_Decoder$renderDictBody = F2(
+	function (name, type_) {
+		return A2(
+			_elm_lang$core$Basics_ops['++'],
+			'dict ',
+			A3(_user$project$Generate_Decoder$renderPropertyDecoder, name, 'Property', type_));
+	});
 var _user$project$Generate_Decoder$renderArrayBody = F2(
 	function (name, type_) {
 		return A2(
@@ -9209,6 +9287,11 @@ var _user$project$Generate_Decoder$renderDecoderBody = function (definition) {
 				_user$project$Generate_Decoder$renderArrayBody,
 				_user$project$Swagger_Definition$getFullName(definition),
 				_user$project$Swagger_Type$getItemsType(_p11._0));
+		case 'Dict_':
+			return A2(
+				_user$project$Generate_Decoder$renderDictBody,
+				_user$project$Swagger_Definition$getFullName(definition),
+				_p11._0);
 		case 'Enum_':
 			return A2(
 				_user$project$Generate_Decoder$renderEnumBody,
@@ -9239,7 +9322,7 @@ var _user$project$Generate_Decoder$renderDecoder = function (definition) {
 		_user$project$Generate_Decoder$renderDecoderBody(definition));
 };
 
-var _user$project$Generate_Headers$renderHeaders = 'module Decoder exposing (..)\n\nimport Json.Decode exposing (Decoder, string, int, float, dict, list, bool, map, value, decodeValue, decodeString, lazy)\nimport Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)\n\n\nmaybe : String -> Decoder a -> Decoder (Maybe a -> b) -> Decoder b\nmaybe name decoder =\n    optional name (map Just decoder) Nothing\n\n\ncustomDecoder : Decoder a -> (a -> Result String b) -> Decoder b\ncustomDecoder decoder toResult =\n    Json.Decode.andThen\n        (\\a ->\n            case toResult a of\n                Ok b ->\n                    Json.Decode.succeed b\n\n                Err err ->\n                    Json.Decode.fail err\n        )\n        decoder\n\n\n';
+var _user$project$Generate_Headers$renderHeaders = 'module Decoder exposing (..)\n\nimport Json.Decode exposing (Decoder, string, int, float, dict, list, bool, map, value, decodeValue, decodeString, lazy)\nimport Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)\nimport Dict exposing (Dict)\n\n\nmaybe : String -> Decoder a -> Decoder (Maybe a -> b) -> Decoder b\nmaybe name decoder =\n    optional name (map Just decoder) Nothing\n\n\ncustomDecoder : Decoder a -> (a -> Result String b) -> Decoder b\ncustomDecoder decoder toResult =\n    Json.Decode.andThen\n        (\\a ->\n            case toResult a of\n                Ok b ->\n                    Json.Decode.succeed b\n\n                Err err ->\n                    Json.Decode.fail err\n        )\n        decoder\n\n\n';
 
 var _user$project$Generate_Swagger$moduleName = function (_p0) {
 	return _user$project$Codegen_Utils$capitalize(

--- a/source/Codegen/Type.elm
+++ b/source/Codegen/Type.elm
@@ -53,6 +53,11 @@ list body =
     wrap "List" body
 
 
+dict : Body -> String
+dict typeName =
+    "Dict String " ++ typeName
+
+
 maybe : Body -> String
 maybe body =
     wrap "Maybe" body

--- a/source/Generate/Decoder.elm
+++ b/source/Generate/Decoder.elm
@@ -7,7 +7,7 @@ import Codegen.Literal exposing (string)
 import Swagger.Definition as Def exposing (Definition, getType, getFullName)
 import Swagger.Type
     exposing
-        ( Type(Object_, Array_, String_, Enum_, Int_, Float_, Bool_, Ref_)
+        ( Type(Object_, Array_, Dict_, String_, Enum_, Int_, Float_, Bool_, Ref_)
         , Properties(Properties)
         , Property(Required, Optional, Default)
         , getItemsType
@@ -34,6 +34,9 @@ renderDecoderBody definition =
 
         Array_ items ->
             renderArrayBody (getFullName definition) (getItemsType items)
+
+        Dict_ typeName ->
+            renderDictBody (getFullName definition) typeName
 
         Enum_ default enum ->
             renderEnumBody (getFullName definition) enum
@@ -68,6 +71,11 @@ renderPrimitiveBody type_ default =
 renderArrayBody : String -> Type -> String
 renderArrayBody name type_ =
     "list " ++ (renderPropertyDecoder name "Item" type_)
+
+
+renderDictBody : String -> Type -> String
+renderDictBody name type_ =
+    "dict " ++ (renderPropertyDecoder name "Property" type_)
 
 
 renderObjectBody : String -> Properties -> String
@@ -117,6 +125,9 @@ renderPropertyDecoder parentName name type_ =
             nestedDecoderName parentName name
 
         Array_ items ->
+            nestedDecoderName parentName name
+
+        Dict_ _ ->
             nestedDecoderName parentName name
 
         Enum_ _ _ ->

--- a/source/Generate/Headers.elm
+++ b/source/Generate/Headers.elm
@@ -7,6 +7,7 @@ renderHeaders =
 
 import Json.Decode exposing (Decoder, string, int, float, dict, list, bool, map, value, decodeValue, decodeString, lazy)
 import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Dict exposing (Dict)
 
 
 maybe : String -> Decoder a -> Decoder (Maybe a -> b) -> Decoder b

--- a/source/Generate/Type.elm
+++ b/source/Generate/Type.elm
@@ -2,11 +2,11 @@ module Generate.Type exposing (..)
 
 import Generate.Utils exposing (typeName, nestedTypeName)
 import Codegen.Utils exposing (sanitize)
-import Codegen.Type exposing (typeAlias, unionType, record, recordField, list, maybe)
+import Codegen.Type exposing (typeAlias, unionType, record, recordField, list, dict, maybe)
 import Swagger.Definition as Def exposing (Definition, getType, getFullName)
 import Swagger.Type
     exposing
-        ( Type(Object_, Array_, String_, Enum_, Int_, Float_, Bool_, Ref_)
+        ( Type(Object_, Array_, Dict_, String_, Enum_, Int_, Float_, Bool_, Ref_)
         , Properties(Properties)
         , Property(Required, Optional, Default)
         , getItemsType
@@ -50,6 +50,9 @@ renderType definition =
             Array_ items ->
                 typeAliasDecl <| list <| renderPropertyType name "Item" <| getItemsType items
 
+            Dict_ type_ ->
+                typeAliasDecl <| dict <| renderPropertyType name "Property" type_
+
             Ref_ ref ->
                 typeAliasDecl <| typeName ref
 
@@ -84,6 +87,9 @@ renderPropertyType parentName name type_ =
             (nestedTypeName parentName name)
 
         Array_ _ ->
+            (nestedTypeName parentName name)
+
+        Dict_ _ ->
             (nestedTypeName parentName name)
 
         Enum_ _ _ ->

--- a/source/Swagger/Flatten.elm
+++ b/source/Swagger/Flatten.elm
@@ -12,7 +12,7 @@ import Swagger.Definition as Definition
         )
 import Swagger.Type
     exposing
-        ( Type(Object_, Array_, String_, Enum_, Int_, Float_, Bool_, Ref_)
+        ( Type(Object_, Array_, Dict_, String_, Enum_, Int_, Float_, Bool_, Ref_)
         , Properties(Properties)
         , Property(Required, Optional)
         , Items(Items)
@@ -46,6 +46,9 @@ flattenEachRoot definition definitions =
 
                 Array_ items ->
                     flattenItems [ name ] items definitions
+
+                Dict_ type_ ->
+                    flattenType [ name ] "Property" type_ definitions
 
                 _ ->
                     definitions
@@ -86,6 +89,9 @@ flattenType parentNames name type_ definitions =
             Array_ items ->
                 flattenItems childParentNames items definitions
                     |> prependSelf
+
+            Dict_ type_ ->
+                flattenType childParentNames "Property" type_ definitions
 
             (Enum_ _ _) as enum ->
                 definitions

--- a/source/Swagger/Type.elm
+++ b/source/Swagger/Type.elm
@@ -8,6 +8,7 @@ type alias Default =
 type Type
     = Object_ Properties
     | Array_ Items
+    | Dict_ Type
       -- TODO: remove default from each type?
     | String_ Default
     | Enum_ Default Enum

--- a/tests/Integration/Decoder.elm
+++ b/tests/Integration/Decoder.elm
@@ -3,7 +3,8 @@ module Integration.Decoder exposing (..)
 import Test exposing (..)
 import Expect exposing (Expectation, fail)
 import Json.Decode exposing (decodeString)
-import Decoder exposing (Article, decodeArticle, decodeErrorResponse, decodeGroup, decodeRules, ArticleDisplaySize(Large, Small))
+import Decoder exposing (Article, decodeArticle, decodeErrorResponse, decodeGroup, decodeRules, decodeLabels, decodeDictWithObject, decodeDictWithRef, ArticleDisplaySize(Large, Small))
+import Dict
 
 
 articleJson =
@@ -129,6 +130,66 @@ expectedRules =
     {}
 
 
+labelsJson =
+    """
+ {
+           "label1": "labelContent",
+           "label2": "labelContent",
+           "label3": "labelContent"
+       }
+     """
+
+
+expectedLabels =
+    Dict.fromList
+        [ ( "label1", "labelContent" )
+        , ( "label2", "labelContent" )
+        , ( "label3", "labelContent" )
+        ]
+
+dictWithObjectJson =
+    """
+     {
+     "label1": {"nestedProperty": "value1"},
+     "label2": {"nestedProperty": "value2"},
+     "label3": {"nestedProperty": "value3"},
+     "label4": {"nestedProperty": "value4"},
+     "label5": {"nestedProperty": "value5"}
+     }
+     """
+
+expectedDictWithObject =
+    Dict.fromList
+        [( "label1", {nestedProperty = Just "value1"})
+        ,( "label2", {nestedProperty = Just "value2"})
+        ,( "label3", {nestedProperty = Just "value3"})
+        ,( "label4", {nestedProperty = Just "value4"})
+        ,( "label5", {nestedProperty = Just "value5"})
+        ]
+
+dictWithRefJson =
+    """
+     {
+       "label1": {},
+       "label2": {},
+       "label3": {},
+       "label4": {},
+       "label5": {}
+     }
+
+     """
+
+expectedDictWithRef =
+    Dict.fromList
+        [( "label1", {})
+        ,( "label2", {})
+        ,( "label3", {})
+        ,( "label4", {})
+        ,( "label5", {})
+        ]
+
+
+
 all : Test
 all =
     describe "Decoder"
@@ -144,4 +205,16 @@ all =
         , test "should decode Rules" <|
             always <|
                 Expect.equal (Ok expectedRules) (decodeString decodeRules rulesJson)
+        , test "should decode labels" <|
+            always <|
+                Expect.equal (Ok expectedLabels) (decodeString decodeLabels labelsJson)
+        , test "should decode empty dict" <|
+            always <|
+                Expect.equal (Ok <| Dict.fromList []) (decodeString decodeLabels "{}")
+        , test "should decode dict with nested object" <|
+            always <|
+                Expect.equal (Ok expectedDictWithObject) (decodeString decodeDictWithObject dictWithObjectJson)
+        , test "should decode dict with nested ref" <|
+            always <|
+                Expect.equal (Ok expectedDictWithRef) (decodeString decodeDictWithRef dictWithRefJson)
         ]

--- a/tests/fixtures/swagger.json
+++ b/tests/fixtures/swagger.json
@@ -144,6 +144,29 @@
     },
     "lowerCaseDefinitionObject": {
       "type": "object"
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "dictWithObject": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "nestedProperty": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "dictWithRef": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/lowerCaseDefinitionObject"
+      }
     }
   }
 }


### PR DESCRIPTION
According to the [Swagger specification]
(http://swagger.io/specification/#model-with-map-dictionary-properties-88)
a dict is defined by the following json:

```
{
  "type": "object",
  "additionalProperties": {
    "type": "string"
  }
}
```
This PR checks if the field `additionalProperties` is defined and
`properties` is undefined. If so, it interprets it as a dict, otherwise
as an object as usual. It will use the nested field `type` as the second
type of the Elm dictionary. The above example would result in a
dictionary `Dict String String` with a decoder `dict string`.

Related to issue #10, related to PR #12, and [Alertmanager
PR](https://github.com/prometheus/alertmanager/pull/698)